### PR TITLE
Backstage catalog owner

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   type: website
   lifecycle: experimental
-  owner: backend-guild
+  owner: group:backend-guild


### PR DESCRIPTION
# Changes

- Removes invalid `spec.owner` entity reference `lpeabody` (it should have been of the form `user:lpeabody`).
- Assigns ownership to `group:backend-guild`.